### PR TITLE
Add HZB occlusion example plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -413,7 +413,44 @@ target_include_directories(example_plugin PUBLIC
 )
 
 target_link_libraries(example_plugin PUBLIC
-	plugin_renderlib
+        plugin_renderlib
+)
+
+unset(CMKR_TARGET)
+unset(CMKR_SOURCES)
+
+# Target hzbocclusion_plugin
+set(CMKR_TARGET hzbocclusion_plugin)
+set(hzbocclusion_plugin_SOURCES "")
+
+list(APPEND hzbocclusion_plugin_SOURCES
+        "examples/hzbocclusion_plugin/Plugin.cpp"
+)
+
+list(APPEND hzbocclusion_plugin_SOURCES
+        cmake.toml
+)
+
+set(CMKR_SOURCES ${hzbocclusion_plugin_SOURCES})
+add_library(hzbocclusion_plugin SHARED)
+
+if(hzbocclusion_plugin_SOURCES)
+        target_sources(hzbocclusion_plugin PRIVATE ${hzbocclusion_plugin_SOURCES})
+endif()
+
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${hzbocclusion_plugin_SOURCES})
+
+target_compile_features(hzbocclusion_plugin PUBLIC
+        cxx_std_23
+)
+
+target_include_directories(hzbocclusion_plugin PUBLIC
+        "include/"
+        "examples/renderlib"
+)
+
+target_link_libraries(hzbocclusion_plugin PUBLIC
+        plugin_renderlib
 )
 
 unset(CMKR_TARGET)

--- a/examples/hzbocclusion_plugin/Plugin.cpp
+++ b/examples/hzbocclusion_plugin/Plugin.cpp
@@ -1,0 +1,32 @@
+#include <uevr/Plugin.hpp>
+#include <openxr/openxr.h>
+
+using namespace uevr;
+
+class HZBOcclusionPlugin : public Plugin {
+public:
+    HZBOcclusionPlugin() = default;
+
+    void on_initialize() override {
+        // Re-enable engine HZB occlusion if UEVR disabled it
+        API::VR::set_mod_value("VR_DisableHZBOcclusion", false);
+        auto set_cvar = API::get()->param()->sdk->functions->set_cvar_int;
+        set_cvar("Renderer", "r.HZBOcclusion", 1);
+
+        if (API::VR::is_openxr()) {
+            auto xr_data = API::get()->param()->openxr;
+            XrInstance instance = xr_data->get_xr_instance();
+            PFN_xrGetVisibilityMaskKHR getMask{nullptr};
+            if (XR_SUCCEEDED(xrGetInstanceProcAddr(instance, "xrGetVisibilityMaskKHR",
+                                                  reinterpret_cast<PFN_xrVoidFunction*>(&getMask))) && getMask) {
+                API::get()->log_info("OpenXR visibility mask extension available");
+            } else {
+                API::get()->log_info("OpenXR visibility mask extension not available");
+            }
+        } else {
+            API::get()->log_info("Runtime is not OpenXR");
+        }
+    }
+};
+
+std::unique_ptr<HZBOcclusionPlugin> g_plugin{ new HZBOcclusionPlugin() };


### PR DESCRIPTION
## Summary
- add a simple plugin that re-enables `r.HZBOcclusion`
- check for the OpenXR visibility mask extension
- expose new plugin target in CMake

## Testing
- `cmake -S . -B build` *(fails: directory iterator cannot open dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687268647fa88330b8de0894233266bf