### PR TITLE
Add CVar plugin example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,6 +419,43 @@ target_link_libraries(example_plugin PUBLIC
 unset(CMKR_TARGET)
 unset(CMKR_SOURCES)
 
+# Target cvar_plugin
+set(CMKR_TARGET cvar_plugin)
+set(cvar_plugin_SOURCES "")
+
+list(APPEND cvar_plugin_SOURCES
+        "examples/cvar_plugin/Plugin.cpp"
+)
+
+list(APPEND cvar_plugin_SOURCES
+        cmake.toml
+)
+
+set(CMKR_SOURCES ${cvar_plugin_SOURCES})
+add_library(cvar_plugin SHARED)
+
+if(cvar_plugin_SOURCES)
+        target_sources(cvar_plugin PRIVATE ${cvar_plugin_SOURCES})
+endif()
+
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${cvar_plugin_SOURCES})
+
+target_compile_features(cvar_plugin PUBLIC
+        cxx_std_23
+)
+
+target_include_directories(cvar_plugin PUBLIC
+        "include/"
+        "examples/renderlib"
+)
+
+target_link_libraries(cvar_plugin PUBLIC
+        plugin_renderlib
+)
+
+unset(CMKR_TARGET)
+unset(CMKR_SOURCES)
+
 # Target sdk-test
 set(CMKR_TARGET sdk-test)
 set(sdk-test_SOURCES "")

--- a/cmake.toml
+++ b/cmake.toml
@@ -155,6 +155,11 @@ type = "plugin"
 sources = ["examples/example_plugin/**.cpp", "examples/example_plugin/**.c"]
 headers = ["examples/example_plugin/**.hpp", "examples/example_plugin/**.h"]
 
+[target.cvar_plugin]
+type = "plugin"
+sources = ["examples/cvar_plugin/**.cpp", "examples/cvar_plugin/**.c"]
+headers = ["examples/cvar_plugin/**.hpp", "examples/cvar_plugin/**.h"]
+
 [target.sdk-test]
 type = "shared"
 sources = ["side-projects/sdk-test/**.cpp", "side-projects/sdk-test/**.c"]

--- a/examples/cvar_plugin/Plugin.cpp
+++ b/examples/cvar_plugin/Plugin.cpp
@@ -1,0 +1,32 @@
+#include <memory>
+#include "uevr/Plugin.hpp"
+
+using namespace uevr;
+
+class CVarPlugin : public Plugin {
+public:
+    void on_initialize() override {
+        API::get()->log_info("CVarPlugin initialized");
+        // Example: disable motion blur using the console manager
+        auto cm = API::get()->get_console_manager();
+        if (cm != nullptr) {
+            if (auto cvar = cm->find_variable(L"r.DefaultFeature.MotionBlur")) {
+                cvar->set(0);
+                API::get()->log_info("Set r.DefaultFeature.MotionBlur to 0");
+            } else {
+                API::get()->log_error("Failed to find r.DefaultFeature.MotionBlur");
+            }
+        }
+    }
+};
+
+extern "C" __declspec(dllexport) void uevr_set_cvar_int(const wchar_t* name, int value) {
+    auto cm = API::get()->get_console_manager();
+    if (cm != nullptr && name != nullptr) {
+        if (auto cvar = cm->find_variable(name)) {
+            cvar->set(value);
+        }
+    }
+}
+
+std::unique_ptr<CVarPlugin> g_plugin{new CVarPlugin()};


### PR DESCRIPTION
## Summary
- add a new plugin example that sets a CVar on initialization
- hook up the new plugin in build files

## Testing
- `cmake --version`


------
https://chatgpt.com/codex/tasks/task_e_6873de9d2fac8330a22b5ffd13cba9f0